### PR TITLE
修复了 imk64 有线构建

### DIFF
--- a/qmk_porting/keyboards/imk64/keymaps/default/qmk_config.h
+++ b/qmk_porting/keyboards/imk64/keymaps/default/qmk_config.h
@@ -1,0 +1,2 @@
+//override macro in mcuconf.h
+#define DCDC_ENABLE 0

--- a/qmk_porting/keyboards/imk64/mcuconf.h
+++ b/qmk_porting/keyboards/imk64/mcuconf.h
@@ -19,7 +19,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // #define DEBUG                Debug_UART1
 #define DEBUG_BAUDRATE       460800
-#define DCDC_ENABLE          1
+
+#ifndef DCDC_ENABLE
+    #define DCDC_ENABLE          1
+#endif
 #define FREQ_SYS             40000000
 #define LSE_ENABLE           0
 #define BLE_SLOT_NUM         4


### PR DESCRIPTION
@Huckies  mcuconf.h 配置的 DCDC_ENABLE 1 对单模似乎不可用， 通过 keymap 文件中 的 qmk_config.h 禁用。现在正常了